### PR TITLE
Make merge_dependabot action run only after the build, lint and typecheck job pass

### DIFF
--- a/.github/workflows/merge_dependabot_pr.yml
+++ b/.github/workflows/merge_dependabot_pr.yml
@@ -7,7 +7,8 @@ permissions:
   contents: write
 
 jobs:
-  merge_dependabot_pr:
+  dependabot:
+    needs: ['build', 'unit-test', 'typecheck']
     runs-on: ubuntu-latest
     steps:
       - name: Checkout source code

--- a/.github/workflows/pr_lint.yml
+++ b/.github/workflows/pr_lint.yml
@@ -4,7 +4,7 @@ on:
     branches: [master]
 
 jobs:
-  unit-test:
+  typecheck:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
To avoid this situation from happening
<img width="921" alt="Screenshot 2021-12-02 at 18 40 04" src="https://user-images.githubusercontent.com/2737103/144474704-70fb5fc4-ef85-42d4-86fb-72b2fbd958d9.png">


