### PR TITLE
Change on event to pull_request_target so workflow has access to secrets

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,7 +1,5 @@
 name: Slack Notification
-on:
-  pull_request:
-    branches: [master]
+on: pull_request_target
 
 jobs:
   slackNotification:


### PR DESCRIPTION
The pull_request event does not have access to secrets because potentially malicious code can be run on a pull request. But the pull_request_target event is similar to pull_request but is different because it points to the base branch of the base repository. From my understanding, a workflow using pull_request_target will only run actions that are in the base repository.

_Since the base branch is part of the base repository itself and not part of a fork, workflows triggered by pull_request_target are trusted and run with access to secrets._